### PR TITLE
fix(search): prevent Cmd+K conflict on Firefox and resolve DOM warning

### DIFF
--- a/src/assets/ts/utils.ts
+++ b/src/assets/ts/utils.ts
@@ -46,6 +46,7 @@ export const navigate = (
     smooth: boolean = true,
     pushState: boolean = true
 ) => {
+    if (!id) return;
     const OFFSET = 4 * 16;
     let el = document.getElementById(id);
     if (el) {

--- a/src/components/LeftBar.vue
+++ b/src/components/LeftBar.vue
@@ -127,6 +127,7 @@ const mouse = {
 
 const keyboard = {
     command_k: (event: KeyboardEvent, handler: HotkeysEvent) => {
+        event.preventDefault();
         if (!is_searching.value) {
             search.reveal();
         }


### PR DESCRIPTION
## 问题背景

在 Firefox 浏览器（尤其是在 macOS 环境下）使用本网站框架时，存在两个问题：

1. **快捷键冲突：** 按下 `Command + K` 会触发 Firefox 默认的浏览器搜索栏，与唤起应用自带的搜索弹窗相冲突。
2. **控制台`warning`：** 访问一些不需要markdown语法中的多级标题的网页的时候，在 F12 开发者工具中会抛出警告，这是由于`utils.ts`中的`navigate`函数缺少对于不存在多级标题的md文件的条件过滤，而firefox将该情况视为warning级别问题，给出“`getElementById` 尝试获取`id`元素失败，返回 `null`”的报错

---

## 修复方案

**拦截默认行为：** 在`LeftBar.vue`中对于`command_k`快捷键的监听函数中，添加了 `event.preventDefault()`，以显式阻止 Firefox 的默认搜索行为，确保优先弹出应用的搜索框。

```ts
const keyboard = {
    command_k: (event: KeyboardEvent, handler: HotkeysEvent) => {
        event.preventDefault(); // +++ line:130
        if (!is_searching.value) {
            search.reveal();
        }
    },
```

**安全的 DOM 访问：** 对通过`utils.ts`中`navigate`函数获取元素增加了一层判空逻辑。这确保了在组件未挂载状态下也能安全处理，从而消除了控制台的警告。

```ts
export const navigate = (
    id: string,
    smooth: boolean = true,
    pushState: boolean = true
) => {
    if (!id) return; // +++ line:49
    const OFFSET = 4 * 16;
    let el = document.getElementById(id);
    if (el) {
        const y = el.getBoundingClientRect().top + window.scrollY - OFFSET;

        window.scrollTo({ top: y, behavior: smooth ? "smooth" : "auto" });
        if (pushState) history.pushState(history.state, "", `#${id}`);
    }
};
```

---

## 测试步骤

1. 在 macOS 下使用 Firefox 浏览器打开项目。
2. 在首页（或其他不需要分级标题的页面下）打开 F12 开发者面板，确保在初始加载或切换页面时，控制台不再出现 `getElementById` 相关的空值警告。
3. 按下快捷键 `Command + K`。
4. 预期表现： 应用自带的搜索框正常弹出，且不会触发 Firefox 浏览器顶部的默认搜索。

## English ver.

## Background & Problem

When using this website framework on Firefox (especially on macOS), two issues occur:

1. **Shortcut Conflict:** Pressing `Command + K` triggers Firefox's default browser search bar, which conflicts with opening the application's built-in search modal.
2. **Console Warning:** When visiting pages that do not require multi-level headings in Markdown, a warning is thrown in the F12 developer tools. This happens because the `Maps` function in `utils.ts` lacks a conditional check for Markdown files without multi-level headings. Firefox treats this as a warning-level issue, logging that `getElementById` failed to fetch the element by `id` and returned `null`.

---

## Solution

**Intercept Default Behavior:** Added `event.preventDefault()` to the `command_k` shortcut listener in `LeftBar.vue`. This explicitly blocks Firefox's default search behavior, ensuring the application's search box takes priority.

```ts
const keyboard = {
    command_k: (event: KeyboardEvent, handler: HotkeysEvent) => {
        event.preventDefault(); // +++ line:130
        if (!is_searching.value) {
            search.reveal();
        }
    },

```

**Safe DOM Access:** Introduced a null-check logic when fetching elements via the `Maps` function in `utils.ts`. This ensures safe handling even when the target element does not exist, thereby eliminating the console warning.

```ts
export const navigate = (
    id: string,
    smooth: boolean = true,
    pushState: boolean = true
) => {
    if (!id) return; // +++ line:49
    const OFFSET = 4 * 16;
    let el = document.getElementById(id);
    if (el) {
        const y = el.getBoundingClientRect().top + window.scrollY - OFFSET;

        window.scrollTo({ top: y, behavior: smooth ? "smooth" : "auto" });
        if (pushState) history.pushState(history.state, "", `#${id}`);
    }
};

```

---

## How to Test

1. Open the project using Firefox on macOS.
2. Open the F12 developer tools on the homepage (or any other page that doesn't require hierarchical headings), and ensure that no `getElementById` related null warnings appear in the console during the initial load or page navigation.
3. Press the `Command + K` shortcut.
4. **Expected Behavior:** The application's built-in search modal opens normally without triggering the Firefox browser's default top search bar.